### PR TITLE
Docker

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/docker-existing-docker-compose
+// If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
+{
+	"name": "Ruby Fundamentals",
+
+	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
+	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+	"dockerComposeFile": [
+		"../docker-compose.yml"
+	],
+
+	// The 'service' property is the name of the service for the container that VS Code should
+	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+	"service": "ruby",
+
+	// The optional 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
+	"workspaceFolder": "/usr/src/ruby-fundamentals",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+
+  },
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": []
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+
+	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+	// "shutdownAction": "none",
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  ruby:
+  #   image: ruby:3.0.3-alpine3.15@sha256:6b3cc3ac047979b58efe2da3bf4a732d4fe4b06d28e48b63753a2752c66a0ef4
+    build:
+      # Setting a context and dockerfile paths allows for Dockerfiles to be stored away in a sub-directory.
+      context: ./ # Context of build, this is where the project files are stored.
+      dockerfile: ./docker/ruby.dockerfile # The path to Dockerfile and name of the dockerfile to be built
+    image: csalmeida/ruby-fundamentals:latest
+    # Docker compose does not allocate a tty so irb would just exit
+    command: sh -c 'while true; do sleep 30; done'
+    # container_name: ruby-fundamentals
+    volumes:
+      # Allows changes made to project directory to be accessed by the container via a bind mount.
+      - ./:/usr/src/ruby-fundamentals

--- a/docker/ruby.dockerfile
+++ b/docker/ruby.dockerfile
@@ -1,0 +1,6 @@
+# FROM ruby:3.0.3-alpine3.15@sha256:8ec4194e3df279ef459ed06724dd455964defcf49857c161154378a0e4df98a9
+FROM ruby:3.0.3@sha256:8999101469defa0278a32d2b2cfc72e735c7f0073165c08520dbd7a3416e04a4
+
+WORKDIR /usr/src/ruby-fundamentals
+
+CMD ["irb"]


### PR DESCRIPTION
Allows the project to run in a Docker container.

Bind mount won't change files from host machine on the fly so it might be best to use VS Code's Remote Container extension or edit the files in the container directly when using a containerized approach.